### PR TITLE
chore: fix upgrade-dev-dependencies workflow

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -59,5 +59,9 @@ project.gitignore.exclude('.vscode')
 
 project.tasks.removeTask('test');
 project.tasks.removeTask('test:update');
+// next version requires node >= 18
+project.package.addField('resolutions', {
+  '@yarnpkg/parsers': '3.0.0-rc.48.1',
+});
 
 project.synth();

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "npm-check-updates": "^16",
     "projen": "^0.72.15"
   },
+  "resolutions": {
+    "@yarnpkg/parsers": "3.0.0-rc.48.1"
+  },
   "engines": {
     "node": ">= 16.20.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,7 +922,7 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@yarnpkg/parsers@^3.0.0-rc.18":
+"@yarnpkg/parsers@3.0.0-rc.48.1", "@yarnpkg/parsers@^3.0.0-rc.18":
   version "3.0.0-rc.48.1"
   resolved "https://registry.yarnpkg.com/@yarnpkg/parsers/-/parsers-3.0.0-rc.48.1.tgz#8636c24c02c888f2602a464edfd7fb113d75e937"
   integrity sha512-qEewJouhRvaecGjbkjz9kMKn96UASbDodNrE5MYy2TrXkHcisIkbMxZdGBYfAq+s1dFtCSx/5H4k5bEkfakM+A==
@@ -4163,9 +4163,9 @@ npm-bundled@^3.0.0:
     npm-normalize-package-bin "^3.0.0"
 
 npm-check-updates@^16:
-  version "16.12.1"
-  resolved "https://registry.yarnpkg.com/npm-check-updates/-/npm-check-updates-16.12.1.tgz#d7407dcc22e3bfe59dfebbd246d46773d1371323"
-  integrity sha512-zY5Z7rAlhekCZfvCuB0jcablWB0VxdnmZF5pJTfUUZUsE65cr0AzGMKjtVEiUFaHslIiYbdXvf67GEJoVMYEXg==
+  version "16.12.2"
+  resolved "https://registry.yarnpkg.com/npm-check-updates/-/npm-check-updates-16.12.2.tgz#37d226da69b93b4d9aec820a6442b572e6a9f264"
+  integrity sha512-N0jeEcak3/+PS1O5JzwJ2+fvmQVv+084O4iRnDtcMBLcr9S7vPOBxwWgsEuNfj3shKFZRYOuh4NHB9nMenCHXA==
   dependencies:
     chalk "^5.3.0"
     cli-table3 "^0.6.3"


### PR DESCRIPTION
The latest version of `@yarnpkg/parsers` has a min node version of 18.

Fixes #